### PR TITLE
Fixing the Twitter and Slack links.

### DIFF
--- a/_includes/hero-banner.html
+++ b/_includes/hero-banner.html
@@ -41,7 +41,7 @@ autoplay on touch devices.
     <div class="hero-banner__copy-inner">
       <h1>Coders for Labour</h1>
       <p>A collection of enthusiastic developers trying to further the interests and values of the Labour Party.</p>
-      <a class="hero-banner__btn btn btn-lg btn-primary" href="https://slacksignup.labour.pm" target="blank">Join us on Slack</a>
+      <a class="hero-banner__btn btn btn-lg btn-primary" href="https://slacksignup.codersforlabour.com" target="blank">Join us on Slack</a>
     </div>
   </div>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -63,13 +63,13 @@
                 <div class="col-sm-3">
                     <h4>Where to find us</h4>
                     <ul class="links">
-                        <li><a href="https://slacksignup.labour.pm/">Slack Group</a>
+                        <li><a href="https://slacksignup.codersforlabour.com/">Slack Group</a>
                         </li>
                         <li><a href="https://trello.com/invite/b/FTiw5SWJ/92ee9cf6981b9c9037ad5a7d1f975dd6/coders-4-corbyn">Trello Board</a>
                         </li>
                         <li><a href="https://www.facebook.com/groups/codersforcorbyn">Facebook Group</a>
                         </li>
-                        <li><a href="https://twitter.com/codersforcorbyn">Twitter</a>
+                        <li><a href="https://twitter.com/codersforlabour">Twitter</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
The Twitter and Slack signup links were broken. After a discussion on
Slack the signup was added to the codersforlabour.com domain.